### PR TITLE
avoid 2FA by adding token authentication

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -5,22 +5,24 @@ from plex_playlist_builder import PlexPlaylistBuilder
 
 
 if __name__ == "__main__":
-	parser = argparse.ArgumentParser()
-
-	parser.add_argument('--username', '-u', help='Plex account username/email', required=True, type=str)
-	parser.add_argument('--password', '-p', help='Plex account password', required=True, type=str)
-	parser.add_argument('--resource', '-r', help='Plex server resource name', required=True, type=str)
-	parser.add_argument('--playlist_title', '-t', help='Name of target playlist to update', default='Music Bot', type=str)
-	parser.add_argument('--track_count', '-c', help='Number of tracks to add to playlist', default=50, type=int)
-
-	args = parser.parse_args()
-
-	print(f'Generating playlist named "{args.playlist_title}" with {args.track_count} tracks...')
-
-	PlexPlaylistBuilder(
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--username', '-u', help='Plex account username/email', default=None, type=str)
+    parser.add_argument('--password', '-p', help='Plex account password', default=None, type=str)
+    parser.add_argument('--resource', '-r', help='Plex server resource name', default=None, type=str)
+    parser.add_argument('--server_url', '-s', help='Plex server url', default=None, type=str)
+    parser.add_argument('--token', '-tk', help='Plex token', default=None, type=str)
+    parser.add_argument('--playlist_title', '-t', help='Name of target playlist to update', default='Music Bot', type=str)
+    parser.add_argument('--track_count', '-c', help='Number of tracks to add to playlist', default=50, type=int)
+    
+    args = parser.parse_args()
+    print(f'Generating playlist named "{args.playlist_title}" with {args.track_count} tracks...')
+    
+    PlexPlaylistBuilder(
 	    username=args.username,
 	    password=args.password,
-	    resource=args.resource
+	    resource=args.resource,
+        server_url=args.server_url,
+        token=args.token,
 	).build_playlist(
 	    playlist_title=args.playlist_title,
 	    track_count=int(args.track_count)

--- a/plex/connection.py
+++ b/plex/connection.py
@@ -1,28 +1,31 @@
 from plexapi.myplex import MyPlexAccount
 
 class PlexConnection():
-	def __init__(self, username=None, password=None, resource=None):
-		self.username = username
-		self.password = password
-		self.resource = resource
-		self._server = None
+    def __init__(self, username=None, password=None, resource=None):
+        self.username = username
+        self.password = password
+        self.resource = resource
+        self._server = None
 
-	@property
-	def music_library(self, section_name='Music'):
-		return self.library.section(section_name)
+    @property
+    def music_library(self, section_name='Music'):
+        return self.library.section(section_name)
 
-	@property
-	def library(self):
-		return self.server.library
+    @property
+    def library(self):
+        return self.server.library
 
-	@property
-	def server(self):
-		if not self._server:
-			self._server = self._setup_server()
-		return self._server
+    @property
+    def server(self):
+        if not self._server:
+            self._server = self._setup_server()
+        return self._server
 
-	def _setup_server(self):
-		print(f'Connecting to Plex server {self.resource}...')
-		account = MyPlexAccount(self.username, self.password)
-		print(f'Connecting to Plex server {self.resource}... DONE.')
-		return account.resource(self.resource).connect()
+    def _setup_server(self):
+        print(f'Connecting to Plex server {self.resource}...')
+        # In plex/connection.py, line 26:
+        two_factor_code = input("Enter your Plex 2FA code: ")
+        account = MyPlexAccount(self.username, self.password, code=two_factor_code)
+
+        print(f'Connecting to Plex server {self.resource}... DONE.')
+        return account.resource(self.resource).connect()

--- a/plex/connection.py
+++ b/plex/connection.py
@@ -1,10 +1,12 @@
-from plexapi.myplex import MyPlexAccount
+from plexapi.myplex import MyPlexAccount, PlexServer
 
 class PlexConnection():
-    def __init__(self, username=None, password=None, resource=None):
+    def __init__(self, username=None, password=None, resource=None, server_url=None, token=None):
         self.username = username
         self.password = password
         self.resource = resource
+        self.server_url = server_url
+        self.token = token
         self._server = None
 
     @property
@@ -23,9 +25,11 @@ class PlexConnection():
 
     def _setup_server(self):
         print(f'Connecting to Plex server {self.resource}...')
-        # In plex/connection.py, line 26:
-        two_factor_code = input("Enter your Plex 2FA code: ")
-        account = MyPlexAccount(self.username, self.password, code=two_factor_code)
 
-        print(f'Connecting to Plex server {self.resource}... DONE.')
-        return account.resource(self.resource).connect()
+        # Use token if available, otherwise fall back to 2FA flow
+        if self.token:
+            return PlexServer(f'http://{self.server_url}:32400', token=self.token)
+        else:
+            two_factor_code = input("Enter your Plex 2FA code: ")
+            account = MyPlexAccount(self.username, self.password, code=two_factor_code)
+            return account.resource(self.resource).connect()

--- a/plex_playlist_builder.py
+++ b/plex_playlist_builder.py
@@ -8,9 +8,9 @@ from utils.weighted_picker import WeightedPicker
 
 
 class PlexPlaylistBuilder():
-	def __init__(self, username=None, password=None, resource=None):
+	def __init__(self, username=None, password=None, resource=None, server_url=None, token=None):
 		plex_library = PlexConnection(
-			username=username, password=password, resource=resource
+			username=username, password=password, resource=resource, server_url=server_url, token=token,
 		).music_library
 		self.music_library = PlexMusic(plex_library)
 


### PR DESCRIPTION

Plex now has a provision for 2FA.

I added an `input` into the original authentication flow that prompts the user for a 2FA code.

I added auth inputs for `server_url` and `token` (e.g., plex `X-Plex-Token`) so the script can run without an additional user input.  The `_setup_server` connection function tries a `token` method first, and falls back to a login requiring 2FA.

My IDE was somehow unhappy with some of the index syntax, which is a bit of changes-that-aren't-changes here.